### PR TITLE
Remove margin-top of image in Header

### DIFF
--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -9,7 +9,6 @@
 }
 
 .Header img {
-  margin-top: 70px;
   margin-bottom: 0px;
   width: 151px;
   height: 141px;


### PR DESCRIPTION
Removed margin-top of an image in Header component to reduce space at top the app.