### PR TITLE
Add logic for setting visibility of back CTA - EC-102

### DIFF
--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -17,3 +17,10 @@
   margin-left: auto;
   margin-right: auto;
 }
+
+.Header .back-cta {
+  text-decoration: none;
+  color: white;
+  display: inline-block;
+  width: 100%;
+}

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -2,9 +2,10 @@ import React from "react";
 import "./Header.css";
 import logo from "../images/logo.png";
 import styled from 'styled-components/macro';
-import { Link } from "react-router-dom";
+import { useLocation, Link } from "react-router-dom";
 
 const BackCTAWrapper = styled.div`
+  visibility: ${ props => props.hasId ? "visible" : "hidden"};
   background-color: #ca0000;
   width: 160px;
   border-radius: 4px;
@@ -21,10 +22,14 @@ const BackCTAWrapper = styled.div`
 
 
 export default function Header() {
-
+  const location = useLocation();
+  const hasId = () => {
+    return location.pathname !== "/";
+  }
+  
   return (
     <div className="Header">
-      <BackCTAWrapper>
+      <BackCTAWrapper hasId={hasId()}>
         <Link to="/" className="back-cta">Back</Link>
       </BackCTAWrapper>
       <img src={logo} alt="Ez-Logo" />

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -5,7 +5,7 @@ import styled from 'styled-components/macro';
 import { useLocation, Link } from "react-router-dom";
 
 const BackCTAWrapper = styled.div`
-  visibility: ${ props => props.hasId ? "visible" : "hidden"};
+  visibility: ${ props => props.notRoot ? "visible" : "hidden"};
   background-color: #ca0000;
   width: 160px;
   border-radius: 4px;
@@ -23,13 +23,13 @@ const BackCTAWrapper = styled.div`
 
 export default function Header() {
   const location = useLocation();
-  const hasId = () => {
+  const notRoot = () => {
     return location.pathname !== "/";
   }
   
   return (
     <div className="Header">
-      <BackCTAWrapper hasId={hasId()}>
+      <BackCTAWrapper notRoot={notRoot()}>
         <Link to="/" className="back-cta">Back</Link>
       </BackCTAWrapper>
       <img src={logo} alt="Ez-Logo" />

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,10 +1,32 @@
 import React from "react";
 import "./Header.css";
 import logo from "../images/logo.png";
+import styled from 'styled-components/macro';
+import { Link } from "react-router-dom";
+
+const BackCTAWrapper = styled.div`
+  background-color: #ca0000;
+  width: 160px;
+  border-radius: 4px;
+  padding: 8px;
+  text-align: center;
+  font-weight: 600;
+  font-size: 1.2rem;
+
+  &:hover,
+  &:focus {
+    background-color: #b80202;
+  }
+`;
+
 
 export default function Header() {
+
   return (
     <div className="Header">
+      <BackCTAWrapper>
+        <Link to="/" className="back-cta">Back</Link>
+      </BackCTAWrapper>
       <img src={logo} alt="Ez-Logo" />
       <h1> EZ Cocktails</h1>
     </div>


### PR DESCRIPTION
@viteshbava Please review this pull request. 
This PR covers the ticket [EC-102](https://viteshbava.atlassian.net/browse/EC-102) and contains the following changes:
1. added the back CTA at top of the Header and applied style to it.
2. added `hasId` function to check whether the current location is home page or not, using `useLocation().pathname` (if the current location is home page, it means there is no id parameter in the url, so I named this function `hasId`).
3. passed `hasId()` as a prop to `<BackCTAWrapper>`
4. added a logic to decide whether to show the back CTA or not.
  - if the current location is home page, set visibility to "hidden" and if not, set visibility to "visible".
  - I used "visiblility" attribute (and not "display") so that the back CTA takes place at home page even though it is invisible, and that header always looks the same.