### PR TITLE
Add logic to SearchBar.js to disable buttons when list is loading - EC-105

### DIFF
--- a/src/components/SearchBar.css
+++ b/src/components/SearchBar.css
@@ -84,9 +84,14 @@
   cursor: pointer;
 }
 
-/* Show the dropdown menu on hover */
-.dropdown:hover .dropdown-content {
+/* Show the dropdown menu on hover (when not disabled)*/
+.dropdown:not(.disabled):hover .dropdown-content {
   display: block;
+}
+
+/* If dropdown menu is disabled, change color */
+.dropdown.disabled .btn {
+  background-color: #bf5c5c;
 }
 
 /* Change the background color of the dropdown button when the dropdown content is shown */

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -1,12 +1,18 @@
-import "./SearchBar.css";
-import React, { useState } from "react";
-import { useCocktailListContext } from "../context/use-context";
-import { useFiltersContext } from "../context/use-context";
+import './SearchBar.css';
+import React, { useState } from 'react';
+import { useCocktailListContext } from '../context/use-context';
+import { useFiltersContext } from '../context/use-context';
+import { CONTEXT_STATUS } from '../context/constants';
 
 const SearchBar = () => {
-  const [message, setMessage] = useState("");
-  const { searchCocktails } = useCocktailListContext();
+  const [message, setMessage] = useState('');
+  const { cocktails, searchCocktails } = useCocktailListContext();
   const { updateFilters } = useFiltersContext();
+
+  const { status } = cocktails;
+  const { LOADING } = CONTEXT_STATUS;
+  const disableSearch = !message || status === LOADING;
+  const disableFilter = status === LOADING;
 
   const handleChange = (event) => {
     setMessage(event.target.value);
@@ -19,36 +25,36 @@ const SearchBar = () => {
   };
 
   const clickHandleUpdateFilter1 = () => {
-    updateFilters({ alcoholic: ["Alcoholic"] });
+    updateFilters({ alcoholic: ['Alcoholic'] });
   };
 
   const clickHandleUpdateFilter2 = () => {
     updateFilters({
-      alcoholic: ["Non alcoholic"],
+      alcoholic: ['Non alcoholic'],
     });
   };
 
   return (
-    <div className="SearchBar">
+    <div className='SearchBar'>
       <input
         onChange={(event) => handleChange(event)}
-        placeholder="Search for a cocktail..."
-        id="search-bar"
+        placeholder='Search for a cocktail...'
+        id='search-bar'
       />
       <button
-        disabled={!message}
-        className="search-btn"
+        disabled={disableSearch}
+        className='search-btn'
         onClick={() => handleSubmit(message)}
       >
         Search
       </button>
 
-      <div className="dropdown">
-        <button className="btn" id="categories">
+      <div className={`dropdown${disableFilter ? ' disabled' : ''}`}>
+        <button className='btn' id='categories'>
           Categories
         </button>
-        <div className="dropdown-content">
-          {" "}
+        <div className='dropdown-content'>
+          {' '}
           <div onClick={clickHandleUpdateFilter1}>Alcoholic</div>
           <div onClick={clickHandleUpdateFilter2}>Non-Alcholic</div>
         </div>


### PR DESCRIPTION
@Paulette-Zaldivar-Flores please review this PR (if you don't have time feel free to pass over to Hyemi)

This PR covers https://viteshbava.atlassian.net/browse/EC-105

This PR ensures the Search and Filter buttons are not-clickable when the cocktail list is being loaded.  This is to stop the user from continuously clicking these buttons when the app is calling the api, to avoid spamming the api.  It would also stop confusing updates from occurring (i.e. if I accidentally double click a button, and I see something render twice, for example).

To test:
* The easiest way is to just refresh the page and while the random cocktail list is being loaded, ensure you cannot click the search or filter buttons (even if you have typed text into the input).
* The buttons should also appear non-clickable when non-clickable (i.e. they should be using your colour change styling).
* Once the list has finished loading, you should now be able to click the buttons.
* If you can think of any edge cases I may have missed, or anything I may have not considered that would cause a problem, let me know.
* Also, if you disagree in general with this whole idea, please let me know and we can discuss.

Thanks!