### PR TITLE
Feature/browser tab titles - EC-99, EC-100

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,37 +7,13 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="Search for your favourite cocktails!"
     />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
-
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
-    <title>React App</title>
+    <meta name="keywords" content="cocktails,drinks,alcohol">
+    <title>EZ Cocktails</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
   </body>
 </html>

--- a/src/components/CocktailDetails/CocktailDetails.js
+++ b/src/components/CocktailDetails/CocktailDetails.js
@@ -1,5 +1,5 @@
-import React from "react";
-import { useParams, Link } from "react-router-dom";
+import React from 'react';
+import { useParams, Link } from 'react-router-dom';
 import {
   Wrapper,
   Header,
@@ -14,17 +14,30 @@ import {
   RecipeTitle,
   RecipeContent,
   RecipeItem,
-} from "./CocktailDetails.styled";
+} from './CocktailDetails.styled';
+import useSetDocumentTitle from '../../hooks/use-setDocumentTitle';
 
 const CocktailDetails = () => {
   const id = +useParams().id;
 
   // use id to update selected cocktail
 
+  /**
+   * @hyemi - when you integrate the CocktailDetails with the Context API, you can delete the following two lines and in the useDocumentTitle hook, you can replace cocktailName with the name of the cocktail you are pulling in from selectedCocktail.  This will then display the cocktail's name in the browser tab title.
+   */
+  const selectedCocktail = { data: { strDrink: 'Test Cocktail Name' } };
+  const cocktailName = selectedCocktail?.data?.strDrink;
+  /** */
+
+  useSetDocumentTitle(cocktailName);
+
   return (
     <Wrapper>
       <Header>
-        <CocktailImage src="https://www.thecocktaildb.com/images/media/drink/vvpxwy1439907208.jpg/preview" alt="Sazerac" />
+        <CocktailImage
+          src='https://www.thecocktaildb.com/images/media/drink/vvpxwy1439907208.jpg/preview'
+          alt='Sazerac'
+        />
         <CocktailName>Sazerac</CocktailName>
       </Header>
       <Main>
@@ -41,22 +54,26 @@ const CocktailDetails = () => {
           <RecipeTitle>Recipe</RecipeTitle>
           <RecipeContent>
             <RecipeItem>
-            Rinse a chilled rocks glass with absinthe, discarding any excess, and set aside.
+              Rinse a chilled rocks glass with absinthe, discarding any excess,
+              and set aside.
             </RecipeItem>
             <RecipeItem>
-              In a mixing glass, muddle the sugar cube, water and the Peychaud’s and Angostura bitters.
+              In a mixing glass, muddle the sugar cube, water and the Peychaud’s
+              and Angostura bitters.
             </RecipeItem>
             <RecipeItem>
-              Add the rye and cognac, fill the mixing glass with ice and stir until well-chilled.
+              Add the rye and cognac, fill the mixing glass with ice and stir
+              until well-chilled.
             </RecipeItem>
+            <RecipeItem>Strain into the prepared glass. </RecipeItem>
             <RecipeItem>
-              Strain into the prepared glass.            </RecipeItem>
-            <RecipeItem>
-              Twist the lemon peel over the drink’s surface to express the peel’s oils, then garnish with the peel.            </RecipeItem>
+              Twist the lemon peel over the drink’s surface to express the
+              peel’s oils, then garnish with the peel.{' '}
+            </RecipeItem>
           </RecipeContent>
         </RecipeWrapper>
       </Main>
-      <Link to="/">Back</Link>
+      <Link to='/'>Back</Link>
     </Wrapper>
   );
 };

--- a/src/components/CocktailDetails/CocktailDetails.js
+++ b/src/components/CocktailDetails/CocktailDetails.js
@@ -38,6 +38,9 @@ const CocktailDetails = () => {
     recipesUI = createRecipesUI();
   }
 
+  // If we have a cocktail name, add it to the browser tab title
+  useSetDocumentTitle(status === SUCCESS && data?.strDrink);
+
   function createIngredientsUI() {
     const ingredients = [];
 
@@ -61,9 +64,6 @@ const CocktailDetails = () => {
 
     return recipesUI;
   }
-
-  // If we have a cocktail name, add it to the browser tab title
-  useSetDocumentTitle(data?.strDrink);
 
   return (
     <Wrapper>

--- a/src/hooks/use-setDocumentTitle.js
+++ b/src/hooks/use-setDocumentTitle.js
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+
+const useSetDocumentTitle = (defaultPageTitle, dynamicPageTitle) => {
+  useEffect(() => {
+    const defaultAppTitle = 'EZ Cocktails';
+    document.title = dynamicPageTitle ? dynamicPageTitle : defaultPageTitle;
+    return () => {
+      document.title = defaultAppTitle;
+    };
+  }, [defaultPageTitle, dynamicPageTitle]);
+};
+
+export default useSetDocumentTitle;

--- a/src/hooks/use-setDocumentTitle.js
+++ b/src/hooks/use-setDocumentTitle.js
@@ -1,9 +1,9 @@
 import { useEffect } from 'react';
 
-const useSetDocumentTitle = (defaultPageTitle, dynamicPageTitle) => {
+const useSetDocumentTitle = (dynamicPageTitle, defaultPageTitle = null) => {
   useEffect(() => {
     const defaultAppTitle = 'EZ Cocktails';
-    document.title = dynamicPageTitle ? dynamicPageTitle : defaultPageTitle;
+    document.title = dynamicPageTitle || defaultPageTitle || defaultAppTitle;
     return () => {
       document.title = defaultAppTitle;
     };


### PR DESCRIPTION
@hmshp please review this PR

This PR covers the following:
* Setting the title that appears in the browser tab to something relevant (instead of just 'React App') - https://viteshbava.atlassian.net/browse/EC-99
* Tidy up of index.html to remove unnecessary comments and add some meta data - https://viteshbava.atlassian.net/browse/EC-100

To test:
* Check that by default, the browser's tab title reads 'EZ Cocktails'
* When viewing the details page for a cocktail, the browser's tab title should include the name of the cocktail being viewed.

Any problems please let me know - thanks!
