### PR TITLE
Cocktail list pagination - EC-106

### DIFF
--- a/src/components/CocktailList/CocktailList.js
+++ b/src/components/CocktailList/CocktailList.js
@@ -16,8 +16,10 @@ const CocktailList = () => {
   const { IDLE, LOADING, SUCCESS, ERROR } = CONTEXT_STATUS;
 
   const allDrinks = drinks?.slice();
+  const haveDrinks = drinks?.length;
   const chunkedCocktails = allDrinks && chunkArrayInGroups(allDrinks, 6);
-  const cocktailList = generateCocktailListUI();
+  const cocktailList =
+    status === SUCCESS && haveDrinks && generateCocktailListUI();
 
   useEffect(() => {
     if (firstRender.current && status === IDLE) {
@@ -57,8 +59,6 @@ const CocktailList = () => {
   function handlePageClick(pageNum) {
     setCurrentPage(pageNum);
   }
-
-  const haveDrinks = cocktailList?.length;
 
   return (
     <>

--- a/src/components/CocktailList/CocktailList.js
+++ b/src/components/CocktailList/CocktailList.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useCocktailListContext } from '../../context/use-context';
 import { Wrapper, Cocktail, CocktailImage } from './CocktailList.styled';
@@ -8,10 +8,15 @@ import { InfoMessage, ErrorMessage } from '../MessageState/MessageState';
 
 const CocktailList = () => {
   const { cocktails, getRandomCocktails } = useCocktailListContext();
+  const [currentPage, setCurrentPage] = useState(1);
   const firstRender = useRef(true);
 
   const { status, error, drinks } = cocktails;
   const { IDLE, LOADING, SUCCESS, ERROR } = CONTEXT_STATUS;
+
+  const allDrinks = drinks?.slice();
+  const chunkedCocktails = allDrinks && chunkArrayInGroups(allDrinks, 6);
+  const cocktailList = generateCocktailListUI();
 
   useEffect(() => {
     if (firstRender.current && status === IDLE) {
@@ -20,18 +25,33 @@ const CocktailList = () => {
     }
   }, [getRandomCocktails, status, IDLE]);
 
-  const cocktailList = drinks?.map((cocktail, i) => {
-    return (
-      <Cocktail key={i}>
-        <Link to={`/cocktails/${cocktail.idDrink}`}>
-          <CocktailImage
-            src={`${cocktail.strDrinkThumb}/preview`}
-            alt={cocktail.strDrink}
-          />
-        </Link>
-      </Cocktail>
-    );
-  });
+  
+
+  function chunkArrayInGroups(arr, size) {
+    let chunkedCocktails = [];
+    for(let i = 0; i < arr.length; i += size) {
+      chunkedCocktails.push(arr.slice(i, i+size));
+    }
+    return chunkedCocktails;
+  }
+
+  function generateCocktailListUI() {
+    if (chunkedCocktails) {
+      const cocktailList = chunkedCocktails[currentPage - 1].map((cocktail, i) => {
+        return (
+          <Cocktail key={i}>
+            <Link to={`/cocktails/${cocktail.idDrink}`}>
+              <CocktailImage
+                src={`${cocktail.strDrinkThumb}/preview`}
+                alt={cocktail.strDrink}
+              />
+            </Link>
+          </Cocktail>
+        );
+      });
+      return cocktailList;
+    }
+  }
 
   const haveDrinks = cocktailList?.length;
 

--- a/src/components/CocktailList/CocktailList.js
+++ b/src/components/CocktailList/CocktailList.js
@@ -54,6 +54,10 @@ const CocktailList = () => {
     }
   }
 
+  function handlePageClick(pageNum) {
+    setCurrentPage(pageNum);
+  }
+
   const haveDrinks = cocktailList?.length;
 
   return (
@@ -64,6 +68,7 @@ const CocktailList = () => {
         <Pagination
           chunkedCocktails={chunkedCocktails}
           currentPage={currentPage}
+          handlePageClick={handlePageClick}
         />
       )}
       {status === SUCCESS && !haveDrinks && (

--- a/src/components/CocktailList/CocktailList.js
+++ b/src/components/CocktailList/CocktailList.js
@@ -11,20 +11,21 @@ const CocktailList = () => {
   const { cocktails, getRandomCocktails } = useCocktailListContext();
   const [currentPage, setCurrentPage] = useState(1);
   const firstRender = useRef(true);
+  const cocktailsPerPage = 9;
 
   const { status, error, drinks } = cocktails;
   const { IDLE, LOADING, SUCCESS, ERROR } = CONTEXT_STATUS;
 
   const allDrinks = drinks?.slice();
   const haveDrinks = drinks?.length;
-  const chunkedCocktails = allDrinks && chunkArrayInGroups(allDrinks, 9);
+  const chunkedCocktails = allDrinks && chunkArrayInGroups(allDrinks, cocktailsPerPage);
   const cocktailList =
     status === SUCCESS && haveDrinks && generateCocktailListUI();
 
   useEffect(() => {
     if (firstRender.current && status === IDLE) {
       firstRender.current = false;
-      getRandomCocktails(9);
+      getRandomCocktails(cocktailsPerPage);
     }
   }, [getRandomCocktails, status, IDLE]);
 
@@ -64,7 +65,7 @@ const CocktailList = () => {
     <>
       {status === LOADING && <Spinner />}
       {status === SUCCESS && haveDrinks && <Wrapper>{cocktailList}</Wrapper>}
-      {status === SUCCESS && (
+      {status === SUCCESS && (drinks.length > cocktailsPerPage) && (
         <Pagination
           chunkedCocktails={chunkedCocktails}
           currentPage={currentPage}

--- a/src/components/CocktailList/CocktailList.js
+++ b/src/components/CocktailList/CocktailList.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef } from "react";
 import { Link } from "react-router-dom";
 import { useCocktailListContext } from "../../context/use-context";
 import { Wrapper, Cocktail, CocktailImage } from "./CocktailList.styled";
@@ -7,9 +7,9 @@ import Spinner from "../UI/Spinner/Spinner";
 import { InfoMessage, ErrorMessage } from "../MessageState/MessageState";
 import Pagination from "../UI/Pagination/Pagination";
 
-const CocktailList = () => {
+const CocktailList = ( { currentPage, setCurrentPage} ) => {
   const { cocktails, getRandomCocktails } = useCocktailListContext();
-  const [currentPage, setCurrentPage] = useState(1);
+  
   const firstRender = useRef(true);
   const cocktailsPerPage = 9;
 

--- a/src/components/CocktailList/CocktailList.js
+++ b/src/components/CocktailList/CocktailList.js
@@ -17,14 +17,14 @@ const CocktailList = () => {
 
   const allDrinks = drinks?.slice();
   const haveDrinks = drinks?.length;
-  const chunkedCocktails = allDrinks && chunkArrayInGroups(allDrinks, 6);
+  const chunkedCocktails = allDrinks && chunkArrayInGroups(allDrinks, 9);
   const cocktailList =
     status === SUCCESS && haveDrinks && generateCocktailListUI();
 
   useEffect(() => {
     if (firstRender.current && status === IDLE) {
       firstRender.current = false;
-      getRandomCocktails(6);
+      getRandomCocktails(9);
     }
   }, [getRandomCocktails, status, IDLE]);
 

--- a/src/components/CocktailList/CocktailList.js
+++ b/src/components/CocktailList/CocktailList.js
@@ -1,10 +1,11 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { Link } from 'react-router-dom';
-import { useCocktailListContext } from '../../context/use-context';
-import { Wrapper, Cocktail, CocktailImage } from './CocktailList.styled';
-import { CONTEXT_STATUS } from '../../context/constants';
-import Spinner from '../UI/Spinner/Spinner';
-import { InfoMessage, ErrorMessage } from '../MessageState/MessageState';
+import React, { useEffect, useRef, useState } from "react";
+import { Link } from "react-router-dom";
+import { useCocktailListContext } from "../../context/use-context";
+import { Wrapper, Cocktail, CocktailImage } from "./CocktailList.styled";
+import { CONTEXT_STATUS } from "../../context/constants";
+import Spinner from "../UI/Spinner/Spinner";
+import { InfoMessage, ErrorMessage } from "../MessageState/MessageState";
+import Pagination from "../UI/Pagination/Pagination";
 
 const CocktailList = () => {
   const { cocktails, getRandomCocktails } = useCocktailListContext();
@@ -25,30 +26,30 @@ const CocktailList = () => {
     }
   }, [getRandomCocktails, status, IDLE]);
 
-  
-
   function chunkArrayInGroups(arr, size) {
     let chunkedCocktails = [];
-    for(let i = 0; i < arr.length; i += size) {
-      chunkedCocktails.push(arr.slice(i, i+size));
+    for (let i = 0; i < arr.length; i += size) {
+      chunkedCocktails.push(arr.slice(i, i + size));
     }
     return chunkedCocktails;
   }
 
   function generateCocktailListUI() {
     if (chunkedCocktails) {
-      const cocktailList = chunkedCocktails[currentPage - 1].map((cocktail, i) => {
-        return (
-          <Cocktail key={i}>
-            <Link to={`/cocktails/${cocktail.idDrink}`}>
-              <CocktailImage
-                src={`${cocktail.strDrinkThumb}/preview`}
-                alt={cocktail.strDrink}
-              />
-            </Link>
-          </Cocktail>
-        );
-      });
+      const cocktailList = chunkedCocktails[currentPage - 1].map(
+        (cocktail, i) => {
+          return (
+            <Cocktail key={i}>
+              <Link to={`/cocktails/${cocktail.idDrink}`}>
+                <CocktailImage
+                  src={`${cocktail.strDrinkThumb}/preview`}
+                  alt={cocktail.strDrink}
+                />
+              </Link>
+            </Cocktail>
+          );
+        }
+      );
       return cocktailList;
     }
   }
@@ -59,14 +60,20 @@ const CocktailList = () => {
     <>
       {status === LOADING && <Spinner />}
       {status === SUCCESS && haveDrinks && <Wrapper>{cocktailList}</Wrapper>}
+      {status === SUCCESS && (
+        <Pagination
+          chunkedCocktails={chunkedCocktails}
+          currentPage={currentPage}
+        />
+      )}
       {status === SUCCESS && !haveDrinks && (
         <InfoMessage
-          title='No cocktails to display'
-          message='Please try searching again, or adjust the filters you may have selected.'
+          title="No cocktails to display"
+          message="Please try searching again, or adjust the filters you may have selected."
         />
       )}
       {status === ERROR && (
-        <ErrorMessage title='Error loading cocktails' message={error.message} />
+        <ErrorMessage title="Error loading cocktails" message={error.message} />
       )}
     </>
   );

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -4,7 +4,7 @@ import { useCocktailListContext } from '../context/use-context';
 import { useFiltersContext } from '../context/use-context';
 import { CONTEXT_STATUS } from '../context/constants';
 
-const SearchBar = () => {
+const SearchBar = ( { setCurrentPage } ) => {
   const [message, setMessage] = useState('');
   const { cocktails, searchCocktails } = useCocktailListContext();
   const { updateFilters } = useFiltersContext();
@@ -21,6 +21,7 @@ const SearchBar = () => {
 
   const handleSubmit = (searchTerm) => {
     console.log(searchTerm);
+    setCurrentPage(1);
     searchCocktails(searchTerm);
   };
 

--- a/src/components/UI/Pagination/Pagination.js
+++ b/src/components/UI/Pagination/Pagination.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { PaginationWrapper, PaginationItem } from "./Pagination.styled";
 
-const Pagination = ({ chunkedCocktails, currentPage }) => {
+const Pagination = ({ chunkedCocktails, currentPage, handlePageClick }) => {
   const paginationBar =
     chunkedCocktails &&
     chunkedCocktails[currentPage - 1]?.map((ct, i) => {
@@ -11,6 +11,7 @@ const Pagination = ({ chunkedCocktails, currentPage }) => {
           pageNum={pageNum}
           isCurrentPage={pageNum === currentPage}
           key={i}
+          onClick={() => handlePageClick(pageNum)}
         />
       );
     });

--- a/src/components/UI/Pagination/Pagination.js
+++ b/src/components/UI/Pagination/Pagination.js
@@ -1,0 +1,21 @@
+import React from "react";
+import { PaginationWrapper, PaginationItem } from "./Pagination.styled";
+
+const Pagination = ({ chunkedCocktails, currentPage }) => {
+  const paginationBar =
+    chunkedCocktails &&
+    chunkedCocktails[currentPage - 1]?.map((ct, i) => {
+      const pageNum = i + 1;
+      return (
+        <PaginationItem
+          pageNum={pageNum}
+          isCurrentPage={pageNum === currentPage}
+          key={i}
+        />
+      );
+    });
+
+  return <PaginationWrapper>{paginationBar}</PaginationWrapper>;
+};
+
+export default Pagination;

--- a/src/components/UI/Pagination/Pagination.js
+++ b/src/components/UI/Pagination/Pagination.js
@@ -3,8 +3,7 @@ import { PaginationWrapper, PaginationItem } from "./Pagination.styled";
 
 const Pagination = ({ chunkedCocktails, currentPage, handlePageClick }) => {
   const paginationBar =
-    chunkedCocktails &&
-    chunkedCocktails[currentPage - 1]?.map((ct, i) => {
+    chunkedCocktails?.map((ct, i) => {
       const pageNum = i + 1;
       return (
         <PaginationItem

--- a/src/components/UI/Pagination/Pagination.styled.js
+++ b/src/components/UI/Pagination/Pagination.styled.js
@@ -1,0 +1,16 @@
+import styled from "styled-components/macro";
+
+export const PaginationWrapper = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 24px;
+  margin-top: 1.5rem;
+`
+
+export const PaginationItem = styled.div`
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background-color: ${props => props.isCurrentPage ? "#CA0000" : "#666666"};
+  cursor: pointer;
+`;

--- a/src/pages/CocktailListPage.js
+++ b/src/pages/CocktailListPage.js
@@ -6,7 +6,9 @@ const CocktailListPage = () => {
   const [currentPage, setCurrentPage] = useState(1);
   return (
     <>
-      <SearchBar />
+      <SearchBar
+        setCurrentPage={setCurrentPage}
+      />
       <CocktailList
         currentPage={currentPage}
         setCurrentPage={setCurrentPage}

--- a/src/pages/CocktailListPage.js
+++ b/src/pages/CocktailListPage.js
@@ -1,12 +1,16 @@
-import React from 'react';
+import React, { useState } from 'react';
 import SearchBar from '../components/SearchBar';
 import CocktailList from '../components/CocktailList/CocktailList';
 
 const CocktailListPage = () => {
+  const [currentPage, setCurrentPage] = useState(1);
   return (
     <>
       <SearchBar />
-      <CocktailList />
+      <CocktailList
+        currentPage={currentPage}
+        setCurrentPage={setCurrentPage}
+      />
     </>
   );
 };


### PR DESCRIPTION
@Paulette-Zaldivar-Flores Please review this PR :)
@viteshbava Feel free to check the code and let me know if there are any issues!

This PR covers the following:
- create the pagination bar and set color of dots conditionally (red for a dot indicating the current page and gray for the others).
- show only the cocktails matching a current page (if there is no search result or there are no more than 9 cocktails, the page bar is not rendered)
- Set `currentPage` to 1 when search button is clicked (because, otherwise, the app might show an error. For example, when we search 'vodka', click page 5 and then search 'strawberry', `currentPage` state value is still 5 even if there are less than 9 cocktails containing 'strawberry' keyword).
- update `currentPage` state when a dot is clicked.
- change number of cocktails in home page from 6 to 9.

When testing, you can check as follows:
- when you first open the app, there is no pagination showing. (since 9 cocktails are rendered, there should be no pagination)
- when you search 'vodka' or 'gin', you can see pagination dots
- when you click one of the gray dots, it is changed into red (the others are gray now) and cocktail lists above also change.
- then (after you changed the page into something other than page 1), search 'strawberry' and check that there is no error occuring.
- when you search something invalid (e.g.sdfsdf) 'No cocktails to display' message should appear on the screen.