### PR TITLE
Fix bug: app crashes when viewing a page then selecting filter- EC-116

### DIFF
--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -26,10 +26,12 @@ const SearchBar = ( { setCurrentPage } ) => {
   };
 
   const clickHandleUpdateFilter1 = () => {
+    setCurrentPage(1);
     updateFilters({ alcoholic: ['Alcoholic'] });
   };
 
   const clickHandleUpdateFilter2 = () => {
+    setCurrentPage(1);
     updateFilters({
       alcoholic: ['Non alcoholic'],
     });


### PR DESCRIPTION
@viteshbava Please review this pull request.

This PR contains the following change:
- add a logic setting currentPage variable’s value to 1 when any option in Category filter is clicked.

Below is the reason why the app crashed when viewing a page then selecting filter:
- A current page state didn’t change even after a user clicked a filter option. 
- For example, when you search for ‘gin’ and click page 3, current page state (currentPage variable) becomes 3. Then, when you click “alcoholic” option in the Category filter, the value of currentPage variable is still 3. If the result of the filtering contains more than 27 cocktails and therefore has at least 3 pages, the app won’t crash. However, if the result of the filtering has less than 3 pages, the app will crash.

If there are any issues, please let me know!