### PR TITLE
Add error and loading state to details page

### DIFF
--- a/src/components/CocktailDetails/CocktailDetails.js
+++ b/src/components/CocktailDetails/CocktailDetails.js
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { useSelectedCocktailContext } from '../../context/use-context';
 import { CONTEXT_STATUS } from '../../context/constants';
+import Spinner from "../UI/Spinner/Spinner";
 import {
   Wrapper,
   Header,
@@ -66,26 +67,32 @@ const CocktailDetails = () => {
   }
 
   return (
-    <Wrapper>
-      <Header>
-        <CocktailImage
-          src={data && data.strDrinkThumb}
-          alt={data && data.strDrink}
-        />
-        <CocktailName>{data && data.strDrink}</CocktailName>
-      </Header>
-      <Main>
-        <IngredientsWrapper>
-          <IngredientsTitle>Ingredients</IngredientsTitle>
-          <IngredientsContent>{ingredientsUI}</IngredientsContent>
-        </IngredientsWrapper>
-        <RecipeWrapper>
-          <RecipeTitle>Recipe</RecipeTitle>
-          <RecipeContent>{recipesUI}</RecipeContent>
-        </RecipeWrapper>
-      </Main>
-      <Link to='/'>Back</Link>
-    </Wrapper>
+    <>
+      { status === LOADING && <Spinner />}
+      { status === SUCCESS &&
+        <Wrapper>
+          <Header>
+            <CocktailImage
+              src={data && data.strDrinkThumb}
+              alt={data && data.strDrink}
+            />
+            <CocktailName>{data && data.strDrink}</CocktailName>
+          </Header>
+          <Main>
+            <IngredientsWrapper>
+              <IngredientsTitle>Ingredients</IngredientsTitle>
+              <IngredientsContent>{ingredientsUI}</IngredientsContent>
+            </IngredientsWrapper>
+            <RecipeWrapper>
+              <RecipeTitle>Recipe</RecipeTitle>
+              <RecipeContent>{recipesUI}</RecipeContent>
+            </RecipeWrapper>
+          </Main>
+          <Link to='/'>Back</Link>
+        </Wrapper>
+      }
+    </>
+    
   );
 };
 

--- a/src/components/CocktailDetails/CocktailDetails.js
+++ b/src/components/CocktailDetails/CocktailDetails.js
@@ -1,8 +1,9 @@
-import React, { useEffect } from 'react';
-import { useParams, Link } from 'react-router-dom';
-import { useSelectedCocktailContext } from '../../context/use-context';
-import { CONTEXT_STATUS } from '../../context/constants';
+import React, { useEffect } from "react";
+import { useParams, Link } from "react-router-dom";
+import { useSelectedCocktailContext } from "../../context/use-context";
+import { CONTEXT_STATUS } from "../../context/constants";
 import Spinner from "../UI/Spinner/Spinner";
+import { ErrorMessage } from "../MessageState/MessageState";
 import {
   Wrapper,
   Header,
@@ -17,13 +18,13 @@ import {
   RecipeTitle,
   RecipeContent,
   RecipeItem,
-} from './CocktailDetails.styled';
-import useSetDocumentTitle from '../../hooks/use-setDocumentTitle';
+} from "./CocktailDetails.styled";
+import useSetDocumentTitle from "../../hooks/use-setDocumentTitle";
 
 const CocktailDetails = () => {
   const { selectedCocktail, updateSelectedCocktail } =
     useSelectedCocktailContext();
-  const { data, status } = selectedCocktail;
+  const { data, status, error } = selectedCocktail;
   const { IDLE, LOADING, SUCCESS, ERROR } = CONTEXT_STATUS;
   const id = +useParams().id;
 
@@ -58,7 +59,7 @@ const CocktailDetails = () => {
   }
 
   function createRecipesUI() {
-    const recipes = data.strInstructions.split('. ');
+    const recipes = data.strInstructions.split(". ");
     const recipesUI = recipes.map((recipe, i) => {
       return <RecipeItem key={i}>{recipe}</RecipeItem>;
     });
@@ -68,8 +69,8 @@ const CocktailDetails = () => {
 
   return (
     <>
-      { status === LOADING && <Spinner />}
-      { status === SUCCESS &&
+      {status === LOADING && <Spinner />}
+      {status === SUCCESS && (
         <Wrapper>
           <Header>
             <CocktailImage
@@ -88,11 +89,13 @@ const CocktailDetails = () => {
               <RecipeContent>{recipesUI}</RecipeContent>
             </RecipeWrapper>
           </Main>
-          <Link to='/'>Back</Link>
+          <Link to="/">Back</Link>
         </Wrapper>
-      }
+      )}
+      {status === ERROR && (
+        <ErrorMessage title="Error loading cocktails" message={error.message} />
+      )}
     </>
-    
   );
 };
 


### PR DESCRIPTION
@Paulette-Zaldivar-Flores Please review this pull request (EC-90, 91)

These are the changes made in this PR:
- add loading state so that users view it when the data is loading 
- add error state so that users view it when there is an error

You can test it by
- typing some url containing an id that doesn't exist (an error message should show)
- changing the url string so it is mis-spelt in `.src/api/cocktailApi.js` (an error message should show)
- checking if you can see a spinner when the data is loading

Thanks!