### PR TITLE
Remove old back CTA not used anymore

### DIFF
--- a/src/components/CocktailDetails/CocktailDetails.js
+++ b/src/components/CocktailDetails/CocktailDetails.js
@@ -89,7 +89,6 @@ const CocktailDetails = () => {
               <RecipeContent>{recipesUI}</RecipeContent>
             </RecipeWrapper>
           </Main>
-          <Link to="/">Back</Link>
         </Wrapper>
       )}
       {status === ERROR && (


### PR DESCRIPTION
- Remove old back CTA at the bottom left corner of CocktailDetails component, as it's not used anymore.