### PR TITLE
Cocktail list - reduce image size and round the border (EC-113, EC-118)

### DIFF
--- a/src/components/CocktailList/CocktailList.styled.js
+++ b/src/components/CocktailList/CocktailList.styled.js
@@ -32,6 +32,7 @@ export const CocktailImage = styled.img`
   aspect-ratio: 1/1;
   object-fit: cover;
   border: 1px solid #ca0000;
+  border-radius: 6px;
 `;
 
 export const Cocktail = styled.li`
@@ -39,6 +40,7 @@ export const Cocktail = styled.li`
   &:hover {
     transform: scale(1.02);
     background-color: black;
+    border-radius: 6px;
   }
 
   &:hover ${CocktailName} {

--- a/src/components/CocktailList/CocktailList.styled.js
+++ b/src/components/CocktailList/CocktailList.styled.js
@@ -1,6 +1,10 @@
 import styled from "styled-components/macro";
 
 export const Wrapper = styled.ul`
+  @media (max-width: 1600px) {
+    width: 85%;
+    margin: 0 auto;
+  }
   color: pink;
   grid-template-columns: repeat(3, 1fr);
   grid-template-rows: repeat(2, 1fr);

--- a/src/components/CocktailList/CocktailList.styled.js
+++ b/src/components/CocktailList/CocktailList.styled.js
@@ -48,6 +48,7 @@ export const Cocktail = styled.li`
   }
   &:hover ${CocktailImage} {
     opacity: 0.3;
+    border: none;
   }
 
   &:active {

--- a/src/components/CocktailList/CocktailList.styled.js
+++ b/src/components/CocktailList/CocktailList.styled.js
@@ -5,7 +5,7 @@ export const Wrapper = styled.ul`
   grid-template-columns: repeat(3, 1fr);
   grid-template-rows: repeat(2, 1fr);
   display: grid;
-  gap: 40px;
+  gap: 80px;
   list-style-type: none;
   padding-left: 0;
 `;

--- a/src/components/Filters/Filters.styled.js
+++ b/src/components/Filters/Filters.styled.js
@@ -3,6 +3,6 @@ import styled from 'styled-components/macro';
 export const FilterWrapper = styled.div`
   display: flex;
   justify-content: space-around;
-  margin: 1rem auto 2rem;
+  margin: 1rem auto 3rem;
   max-width: 50rem;
 `;


### PR DESCRIPTION
@Paulette-Zaldivar-Flores Please review this PR.

This PR contains the following changes:
- Reduced the size of cocktail images by increasing the gap between images.
- Increased the space between the filters and the cocktail list as there was not enough space there before.
- Reduced the cocktail list's width to 85% when the device width is equal to or less than 1600px (so that you can see a little more part of the cocktail list in a smaller PC).
- Rounded the corner of each picture in the cocktail list
- Removed the border of the picture when it is hovered, as I noticed that grayed out cocktail images don't go well with the red border.

Please check if it looks good and let me know if there is any issue.
Thanks!