### PR TITLE
bug - flash of previous cocktail - EC-120

### DIFF
--- a/src/components/CocktailDetails/CocktailDetails.js
+++ b/src/components/CocktailDetails/CocktailDetails.js
@@ -1,9 +1,9 @@
-import React, { useEffect } from "react";
-import { useParams, Link } from "react-router-dom";
-import { useSelectedCocktailContext } from "../../context/use-context";
-import { CONTEXT_STATUS } from "../../context/constants";
-import Spinner from "../UI/Spinner/Spinner";
-import { ErrorMessage } from "../MessageState/MessageState";
+import React, { useEffect } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { useSelectedCocktailContext } from '../../context/use-context';
+import { CONTEXT_STATUS } from '../../context/constants';
+import Spinner from '../UI/Spinner/Spinner';
+import { ErrorMessage } from '../MessageState/MessageState';
 import {
   Wrapper,
   Header,
@@ -18,11 +18,11 @@ import {
   RecipeTitle,
   RecipeContent,
   RecipeItem,
-} from "./CocktailDetails.styled";
-import useSetDocumentTitle from "../../hooks/use-setDocumentTitle";
+} from './CocktailDetails.styled';
+import useSetDocumentTitle from '../../hooks/use-setDocumentTitle';
 
 const CocktailDetails = () => {
-  const { selectedCocktail, updateSelectedCocktail } =
+  const { selectedCocktail, updateSelectedCocktail, clearSelectedCocktail } =
     useSelectedCocktailContext();
   const { data, status, error } = selectedCocktail;
   const { IDLE, LOADING, SUCCESS, ERROR } = CONTEXT_STATUS;
@@ -30,7 +30,8 @@ const CocktailDetails = () => {
 
   useEffect(() => {
     updateSelectedCocktail(id);
-  }, [id]);
+    return clearSelectedCocktail;
+  }, [id, updateSelectedCocktail, clearSelectedCocktail]);
 
   let ingredientsUI;
   let recipesUI;
@@ -52,7 +53,7 @@ const CocktailDetails = () => {
       data[IngredientPropName] &&
         ingredients.push({
           strIngredient: data[IngredientPropName],
-          strMeasure: data[MeasurePropName] || "",
+          strMeasure: data[MeasurePropName] || '',
         });
     }
 
@@ -69,7 +70,7 @@ const CocktailDetails = () => {
   }
 
   function createRecipesUI() {
-    const recipes = data.strInstructions.split(". ");
+    const recipes = data.strInstructions.split('. ');
     const recipesUI = recipes.map((recipe, i) => {
       return <RecipeItem key={i}>{recipe}</RecipeItem>;
     });
@@ -102,7 +103,7 @@ const CocktailDetails = () => {
         </Wrapper>
       )}
       {status === ERROR && (
-        <ErrorMessage title="Error loading cocktails" message={error.message} />
+        <ErrorMessage title='Error loading cocktails' message={error.message} />
       )}
     </>
   );

--- a/src/context/actions/selectedCocktail-actions.js
+++ b/src/context/actions/selectedCocktail-actions.js
@@ -50,11 +50,11 @@ export default function SelectedCocktailContextProvider({ children }) {
   }, []);
 
   // CLEAR COCKTAIL
-  const clearSelectedCocktail = async () => {
+  const clearSelectedCocktail = useCallback(async () => {
     selectedCocktailDispatcher({
       type: SELCOCKTAIL_ACTIONS.CLEAR,
     });
-  };
+  }, []);
 
   return (
     <SelectedCocktailContext.Provider


### PR DESCRIPTION
@hmshp please review this PR

This PR covers the jira ticket: https://viteshbava.atlassian.net/browse/EC-120

To test - please follow steps in Jira ticket.

Notes:
* This was very subtle and hard to notice, however if you check in the dev environment and look very carefully, you'll be able to notice a very quick flash of the previously viewed cocktail image.
* We still see an empty circle before the new image loads - this is okay; the fix for that (if we have time) is covered in another ticket.
* To resolve this, I just added a return statement to the useEffect which clears the current cocktail before the component unmounts.  This way, the next time the component mounts, the previous cocktail's details won't be there and the status will be IDLE, therefore nothing will be displayed until we have new data.
* To keep the code following best practices, I included all dependencies in the useEffect in the dependency array, and wrapped the clear current cocktail function in the Context API in a useCallback.

Any problems/questions - please let me know!