### PR TITLE
Feature/cursor in search bar by default - EC-121

### DIFF
--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -35,6 +35,7 @@ const SearchBar = () => {
         id='search-bar'
         onKeyDown={handleKeyPress}
         value={message}
+        autoFocus
       />
       <Button
         disabled={disableSearch}


### PR DESCRIPTION
- Add `autoFocus` attribute to the search input tag so that this the curser is automatically be placed in the search input field. 
