### PR TITLE
autofocus on SearchBar should not be set if in phone or tablet view - EC-123

### DIFF
--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -34,7 +34,7 @@ const SearchBar = () => {
         placeholder='Search for a cocktail...'
         onKeyDown={handleKeyPress}
         value={message}
-        autoFocus
+        autoFocus={window.screen.width > 768}
       />
       <Button disabled={disableSearch} onClick={() => handleSubmit(message)}>
         Search


### PR DESCRIPTION
@hmshp please review this PR - it covers Jira bug EC-123

This is a small thing I noticed, and you can only notice it using the app on a phone (or any touch screen device with no keyboard I think).  Basically, the autofocus on the SearchBar is a good thing, but on a phone, when you return to the Cocktail List from the Cocktail Details page, the autofocus causes the keyboard to automatically appear, which is kind of annoying.

So I added some logic to the component so it only sets that property to true if the width of the window implies the user is on a phone or tablet, and therefore using a touchscreen.

You'll probably only be able to test this properly once you merge to develop and then open the develop URL on a phone, so feel free to just merge this PR and check that way.  If there's any problems let me know.

Thanks!