### PR TITLE
Remove autofocus on input to improve accessibility

### DIFF
--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -37,7 +37,6 @@ const SearchBar = () => {
         placeholder='Search for a cocktail...'
         onKeyDown={handleKeyPress}
         value={message}
-        autoFocus={window.screen.width > 768}
       />
       <Button disabled={disableSearch} onClick={() => handleSubmit(message)}>
         Search


### PR DESCRIPTION
This PR contains the following change:

remove the autofocus attribute on input to improve accessibility,
as screen-readers "teleport" their user to the element with autofocus attribute.